### PR TITLE
Add composer vendor bin to path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ Includes
 * [composer](https://github.com/composer/composer) (1.9.1)
 * [xdebug](https://xdebug.org/) (2.8.0)
 
-You can use your own ini files in the config folder for each Flatpak. e.g. for Visual Studio Code
-`~/.var/app/com.visualstudio.code/config/php/7.3/ini` or `/var/config/php/7.3/ini` from a sandboxed shell.
+Each Flatpak can have its own custom php configuration files.
+e.g. for Visual Studio Code
+`~/.var/app/com.visualstudio.code/config/php/7.3/ini/my-custom.ini` or `/var/config/php/7.3/ini/my-custom.ini` from a sandboxed shell.
+
+Global composer installs are limited to the Flatpak they were installed in.
 
 #### Troubleshooting
 `/usr/bin/env: ‘php’: No such file or directory`

--- a/org.freedesktop.Sdk.Extension.php73.json
+++ b/org.freedesktop.Sdk.Extension.php73.json
@@ -282,7 +282,7 @@
 					"type": "script",
 					"dest-filename": "enable.sh",
 					"commands": [
-						"export PATH=$PATH:/usr/lib/sdk/php73/bin"
+						"export PATH=$PATH:/usr/lib/sdk/php73/bin:/var/config/composer/vendor/bin"
 					]
 				},
 				{
@@ -293,3 +293,4 @@
 		}
 	]
 }
+


### PR DESCRIPTION
Alternative to https://github.com/flathub/org.freedesktop.Sdk.Extension.php73/pull/15

Adds the global (but not really global) vendor bin to the path, so globally installed composer binaries are available. 